### PR TITLE
[Amend] Change behavior of `>>` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+### Amends
+- Change behavior of `>>` operator. It returns empty `Iterable` when `count` parameter is greater than it's `length`.
+
 ## 0.1.1
 ### Amends
 - Change `whereNotNull` to `getter`.
@@ -9,5 +13,5 @@
 - The `windowedAndTransform` returns `Iterable<R>`. I accidentally wrote the wrong return type.
 
 ## 0.1.0
-
+### Updates
 - Implement `Iterable`.

--- a/lib/src/kt_iterable.dart
+++ b/lib/src/kt_iterable.dart
@@ -1089,7 +1089,9 @@ extension KtcIterable<E> on Iterable<E> {
   /// looks useful.
   Iterable<E> operator >>(int count) => count.isNegative
       ? throw ArgumentError.value(count, 'count', 'Cannot be negative')
-      : take(length - count);
+      : count > length
+          ? Iterable<E>.empty()
+          : take(length - count);
 
   /// Returns a [Iterable] containing all elements that are contained by both
   /// this collection and the specified collection.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ktc_dart
 description: A package that implemented the features of the `Collections` library of `Kotlin` (v1.5).
-version: 0.1.1
+version: 0.1.2
 
 repository: https://github.com/Sugyo-In/ktc_dart.git
 issue_tracker: https://github.com/Sugyo-In/ktc_dart/issues

--- a/test/kt_iterable_test.dart
+++ b/test/kt_iterable_test.dart
@@ -1109,13 +1109,13 @@ void main() {
     });
 
     test('>>', () {
-      expect(() => empty >> 1, throwsA(isArgumentError));
+      expect(empty >> 1, []);
       expect(() => iterable >> -1, throwsA(isArgumentError));
       expect(iterable >> 0, [0, 1, 2]);
       expect(iterable >> 1, [0, 1]);
       expect(iterable >> 2, [0]);
       expect(iterable >> 3, []);
-      expect(() => iterable >> 4, throwsA(isRangeError));
+      expect(iterable >> 4, []);
     });
 
     test('^', () {


### PR DESCRIPTION
It returns empty `Iterable` when `count` parameter is greater than it's `length`.